### PR TITLE
ci(github-actions): Fix indentation in maven.yml for consistency

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
     - name: Checkout code
-    - uses: actions/checkout@v4 # Action to check out the repository code
+      uses: actions/checkout@v4 # Action to check out the repository code
 
     - name: Set up JDK 17
       uses: actions/setup-java@v4


### PR DESCRIPTION
This pull request makes a minor formatting adjustment in the `.github/workflows/maven.yml` file. The change ensures proper indentation for the `uses` property in the "Checkout code" step.