### PR TITLE
Fix/app tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,37 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main", "develop" ] # Trigger on pushes to main and develop branches
+  pull_request:
+    branches: [ "main" ] # Trigger on pull requests targeting main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # Use the latest Ubuntu virtual machine
+    
+    steps:
+    - name: Checkout code
+    - uses: actions/checkout@v4 # Action to check out the repository code
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17' # Javer Version of Spring Boot app
+        distribution: 'temurin' # Recommended distribution for OpenJDK
+        cache: maven # Cache Maven dependencies to speed up builds
+        
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml # Run Maven build, -B for batch mode (non-interactive)
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,20 @@
+# H2 In-Memory Database Configuration for Tests/CI
+spring:
+  datasource:
+    url: jdbc:h2:mem:fapdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop # Enusres a clean database for each test run
+    properties:
+      hibernate:
+        format_sql: true
+
+# JWT Configuration for Tests
+jwt:
+  secret: yourTestJwtSecret1234567890abcdefghijklmnopqrstuvwxyz # Make it long enough (e.g., 256 bits/32 characters base64 encoded for HS256)
+  expiration: 3600 # 1 hour in seconds

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,29 +1,16 @@
-# Friends and Places Application Configuration
-# This file contains the configuration settings for the Friends and Places application.
-# Spring Configuration properties are defined here.
+# Default Application Configuration
 spring:
   application:
-    name: friends_and_places
-  config:
-    import:
-      - optional:classpath:application-${spring.profiles.active}.yml
-  # DataSource Configuration
-  datasource:
-    dirver-class-name: org.postgresql.Driver
-  # JPA Configuration
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-        current_session_context_class: thread
-        format_sql: true
-        jdbc.lob.non_contextual_creation: true
+    name: FriendsAndPlaces
 
-# Server Configuration
+# Default profile to activate if none specified (e.g., for local running without a profile)
+  profiles:
+    active: dev
+
+# General JPA Settings
+  jpa:
+    open-in-view: false # Good practice for REST APIs to avoid lazy loading issues
+
+# Server Port
 server:
-  error:
-    include-message: always
-  port: 8080
+  port: 8080 # Default port for the application

--- a/src/test/java/de/whs/wi/friends_and_places/FriendsAndPlacesApplicationTests.java
+++ b/src/test/java/de/whs/wi/friends_and_places/FriendsAndPlacesApplicationTests.java
@@ -2,12 +2,15 @@ package de.whs.wi.friends_and_places;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test") // Use the "test" profile for testing
 class FriendsAndPlacesApplicationTests {
 
 	@Test
 	void contextLoads() {
+		// This test simply checks if the application context loads successfully.
 	}
 
 }


### PR DESCRIPTION
This pull request introduces changes to improve testing and configuration for the project, including the addition of an H2 in-memory database for tests, updates to the default application configuration, and the use of a specific profile for testing. It also includes minor updates to the CI workflow and test dependencies.

### Testing Enhancements:
* Added H2 in-memory database configuration in `application-test.yml` for use during testing and CI, including settings for the datasource, JPA, and JWT configuration.
* Updated `FriendsAndPlacesApplicationTests` to use the "test" profile by adding the `@ActiveProfiles("test")` annotation, ensuring the correct configuration is loaded during tests.

### Configuration Updates:
* Refactored `application.yml` to simplify and clarify default application settings, including setting the default profile to `dev`, removing unused PostgreSQL-specific configurations, and disabling `open-in-view` for better REST API practices.

### Dependency Updates:
* Added the H2 database dependency (`com.h2database:h2`) with `runtime` scope in `pom.xml` to support the in-memory database for tests.

### CI Workflow:
* Fixed indentation in the `maven.yml` GitHub Actions workflow for consistency.