### PR TITLE
Error handling

### DIFF
--- a/src/main/java/de/whs/wi/friends_and_places/error/ApiError.java
+++ b/src/main/java/de/whs/wi/friends_and_places/error/ApiError.java
@@ -1,0 +1,23 @@
+package de.whs.wi.friends_and_places.error;
+
+import java.time.LocalDateTime;
+
+/**
+ * Standardized API error response format.
+ * This record represents the structure of error responses sent to clients.
+ */
+public record ApiError(
+        String path,
+        String message,
+        int statusCode,
+        String statusName,
+        LocalDateTime timestamp,
+        String errorType
+) {
+    /**
+     * Create a new ApiError with the current timestamp.
+     */
+    public static ApiError create(String path, String message, int statusCode, String statusName, String errorType) {
+        return new ApiError(path, message, statusCode, statusName, LocalDateTime.now(), errorType);
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/error/AuthenticationException.java
+++ b/src/main/java/de/whs/wi/friends_and_places/error/AuthenticationException.java
@@ -1,0 +1,10 @@
+package de.whs.wi.friends_and_places.error;
+
+/**
+ * Exception thrown when authentication fails (invalid credentials, token issues, etc.).
+ */
+public class AuthenticationException extends RuntimeException {
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/error/DuplicateResourceException.java
+++ b/src/main/java/de/whs/wi/friends_and_places/error/DuplicateResourceException.java
@@ -1,0 +1,10 @@
+package de.whs.wi.friends_and_places.error;
+
+/**
+ * Exception thrown when duplicate data is detected (e.g., user with existing email).
+ */
+public class DuplicateResourceException extends RuntimeException {
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/error/GlobalExceptionHandler.java
+++ b/src/main/java/de/whs/wi/friends_and_places/error/GlobalExceptionHandler.java
@@ -1,0 +1,175 @@
+package de.whs.wi.friends_and_places.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Global exception handler for the application.
+ * This class handles exceptions thrown by controllers and converts them to standardized API responses.
+ */
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Handle resource not found exceptions.
+     */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<ApiError> handleResourceNotFoundException(
+            ResourceNotFoundException ex,
+            HttpServletRequest request) {
+
+        ApiError error = ApiError.create(
+                request.getRequestURI(),
+                ex.getMessage(),
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "NOT_FOUND"
+        );
+
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * Handle duplicate resource exceptions.
+     */
+    @ExceptionHandler(DuplicateResourceException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ResponseEntity<ApiError> handleDuplicateResourceException(
+            DuplicateResourceException ex,
+            HttpServletRequest request) {
+
+        ApiError error = ApiError.create(
+                request.getRequestURI(),
+                ex.getMessage(),
+                HttpStatus.CONFLICT.value(),
+                HttpStatus.CONFLICT.getReasonPhrase(),
+                "CONFLICT"
+        );
+
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
+
+    /**
+     * Handle authentication exceptions.
+     */
+    @ExceptionHandler({AuthenticationException.class, BadCredentialsException.class})
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity<ApiError> handleAuthenticationException(
+            RuntimeException ex,
+            HttpServletRequest request) {
+
+        ApiError error = ApiError.create(
+                request.getRequestURI(),
+                ex.getMessage(),
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "AUTHENTICATION_ERROR"
+        );
+
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    /**
+     * Handle validation exceptions.
+     */
+    @ExceptionHandler({ValidationException.class, MethodArgumentNotValidException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ApiError> handleValidationException(
+            Exception ex,
+            HttpServletRequest request) {
+
+        String message = ex.getMessage();
+        if (ex instanceof MethodArgumentNotValidException validationEx) {
+            Map<String, String> errors = new HashMap<>();
+            validationEx.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+            );
+            message = "Validation failed: " + errors;
+        }
+
+        ApiError error = ApiError.create(
+                request.getRequestURI(),
+                message,
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "VALIDATION_ERROR"
+        );
+
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Handle access denied exceptions.
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<ApiError> handleAccessDeniedException(
+            AccessDeniedException ex,
+            HttpServletRequest request) {
+
+        ApiError error = ApiError.create(
+                request.getRequestURI(),
+                "Access denied: " + ex.getMessage(),
+                HttpStatus.FORBIDDEN.value(),
+                HttpStatus.FORBIDDEN.getReasonPhrase(),
+                "ACCESS_DENIED"
+        );
+
+        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * Handle type mismatch exceptions (e.g., invalid ID format).
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ApiError> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException ex,
+            HttpServletRequest request) {
+
+        String message = String.format("Parameter '%s' should be of type %s",
+                ex.getName(), ex.getRequiredType().getSimpleName());
+
+        ApiError error = ApiError.create(
+                request.getRequestURI(),
+                message,
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "TYPE_MISMATCH"
+        );
+
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Fallback handler for any unhandled exceptions.
+     */
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ApiError> handleGlobalException(
+            Exception ex,
+            HttpServletRequest request) {
+
+        ApiError error = ApiError.create(
+                request.getRequestURI(),
+                "An unexpected error occurred: " + ex.getMessage(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                "INTERNAL_SERVER_ERROR"
+        );
+
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/error/ResourceNotFoundException.java
+++ b/src/main/java/de/whs/wi/friends_and_places/error/ResourceNotFoundException.java
@@ -1,0 +1,14 @@
+package de.whs.wi.friends_and_places.error;
+
+/**
+ * Exception thrown when a requested resource is not found.
+ */
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s: '%s'", resourceName, fieldName, fieldValue));
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/error/ValidationException.java
+++ b/src/main/java/de/whs/wi/friends_and_places/error/ValidationException.java
@@ -1,0 +1,10 @@
+package de.whs.wi.friends_and_places.error;
+
+/**
+ * Exception thrown when input validation fails.
+ */
+public class ValidationException extends RuntimeException {
+    public ValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/util/JwtUtil.java
+++ b/src/main/java/de/whs/wi/friends_and_places/util/JwtUtil.java
@@ -42,7 +42,15 @@ public class JwtUtil {
 
     // Extracts all claims from the JWT token
     private Claims extractAllClaims(String token) {
-        return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+        try {
+            return Jwts.parser()
+                    .setSigningKey(secret)
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (io.jsonwebtoken.SignatureException e) {
+            // Re-throw the SignatureException to ensure it's properly propagated
+            throw new io.jsonwebtoken.SignatureException("Invalid JWT signature", e);
+        }
     }
 
     // Checks if the JWT token is expired
@@ -70,8 +78,9 @@ public class JwtUtil {
 
     // Validates the JWT token by checking if the username matches and if the token is not expired
     public Boolean validateToken(String token, UserDetails userDetails) {
+        // This will throw exceptions like SignatureException, ExpiredJwtException, or MalformedJwtException
+        // if the token is invalid, which will be propagated to the caller
         final String username = extractUsername(token);
         return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
     }
 }
-      


### PR DESCRIPTION
This pull request introduces a comprehensive error-handling framework for the application, including standardized API error responses, custom exception classes, and a global exception handler. It also integrates these enhancements into the `UserServiceImpl` and `JwtUtil` classes for improved validation and error reporting.

### Error Handling Framework:

* Added the `ApiError` record to define a standardized structure for API error responses, including fields like `path`, `message`, `statusCode`, `timestamp`, and `errorType`. A factory method was provided to create instances with the current timestamp. (`src/main/java/de/whs/wi/friends_and_places/error/ApiError.java`)

* Introduced custom exception classes for specific error scenarios:
  - `AuthenticationException` for authentication failures.
  - `DuplicateResourceException` for duplicate data conflicts.
  - `ResourceNotFoundException` for missing resources, with an overloaded constructor for detailed error messages.
  - `ValidationException` for input validation errors.

* Implemented `GlobalExceptionHandler` to handle exceptions globally and return standardized `ApiError` responses for various scenarios, such as resource not found, validation errors, authentication failures, and more. (`src/main/java/de/whs/wi/friends_and_places/error/GlobalExceptionHandler.java`)

### Integration with `UserServiceImpl`:

* Replaced `IllegalArgumentException` with `ValidationException` for null or incomplete user registration data.

* Threw `DuplicateResourceException` for existing users with the same username or email during registration.

* Updated `findById` to throw `ResourceNotFoundException` if a user with the given ID does not exist.

* Added error handling for authentication failures in the `authenticate` method, throwing `AuthenticationException` for invalid credentials.

### Updates to `JwtUtil`:

* Enhanced error handling in `extractAllClaims` to catch and re-throw `SignatureException` with a detailed message for invalid JWT signatures.

* Improved `validateToken` to propagate exceptions like `SignatureException` or `ExpiredJwtException` for invalid tokens.