### PR TITLE
feat(user): Add friend management functionality to User model

### DIFF
--- a/src/main/java/de/whs/wi/friends_and_places/controller/FriendController.java
+++ b/src/main/java/de/whs/wi/friends_and_places/controller/FriendController.java
@@ -1,0 +1,208 @@
+package de.whs.wi.friends_and_places.controller;
+
+import de.whs.wi.friends_and_places.controller.dto.FriendRequestDTO;
+import de.whs.wi.friends_and_places.controller.dto.UserDTO;
+import de.whs.wi.friends_and_places.model.FriendRequest;
+import de.whs.wi.friends_and_places.model.User;
+import de.whs.wi.friends_and_places.service.FriendService;
+import de.whs.wi.friends_and_places.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/friends")
+@Tag(name = "Friends", description = "API endpoints for managing friends and friend requests")
+public class FriendController {
+
+    private final FriendService friendService;
+    private final UserService userService;
+
+    @Autowired
+    public FriendController(FriendService friendService, UserService userService) {
+        this.friendService = friendService;
+        this.userService = userService;
+    }
+
+    @Operation(summary = "Send a friend request")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request sent successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request or receiver not found"),
+            @ApiResponse(responseCode = "409", description = "Friend request already exists or users are already friends")
+    })
+    @PostMapping("/requests/{receiverId}")
+    public ResponseEntity<FriendRequestDTO> sendFriendRequest(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long receiverId) {
+
+        User sender = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        FriendRequest request = friendService.sendFriendRequest(sender, receiverId);
+        return new ResponseEntity<>(convertToDTO(request), HttpStatus.OK);
+    }
+
+    @Operation(summary = "Accept a friend request")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request accepted successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request or request not found"),
+            @ApiResponse(responseCode = "403", description = "User is not the receiver of the request")
+    })
+    @PostMapping("/requests/{requestId}/accept")
+    public ResponseEntity<FriendRequestDTO> acceptFriendRequest(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long requestId) {
+
+        User user = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        FriendRequest request = friendService.acceptFriendRequest(requestId, user);
+        return new ResponseEntity<>(convertToDTO(request), HttpStatus.OK);
+    }
+
+    @Operation(summary = "Decline a friend request")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request declined successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request or request not found"),
+            @ApiResponse(responseCode = "403", description = "User is not the receiver of the request")
+    })
+    @PostMapping("/requests/{requestId}/decline")
+    public ResponseEntity<FriendRequestDTO> declineFriendRequest(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long requestId) {
+
+        User user = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        FriendRequest request = friendService.declineFriendRequest(requestId, user);
+        return new ResponseEntity<>(convertToDTO(request), HttpStatus.OK);
+    }
+
+    @Operation(summary = "Cancel a friend request")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request canceled successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request or request not found"),
+            @ApiResponse(responseCode = "403", description = "User is not the sender of the request")
+    })
+    @PostMapping("/requests/{requestId}/cancel")
+    public ResponseEntity<FriendRequestDTO> cancelFriendRequest(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long requestId) {
+
+        User user = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        FriendRequest request = friendService.cancelFriendRequest(requestId, user);
+        return new ResponseEntity<>(convertToDTO(request), HttpStatus.OK);
+    }
+
+    @Operation(summary = "Get all pending friend requests received by the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of pending friend requests received")
+    })
+    @GetMapping("/requests/received")
+    public ResponseEntity<List<FriendRequestDTO>> getReceivedFriendRequests(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        User user = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        List<FriendRequest> requests = friendService.getReceivedPendingRequests(user);
+        List<FriendRequestDTO> requestDTOs = requests.stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+
+        return new ResponseEntity<>(requestDTOs, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Get all pending friend requests sent by the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of pending friend requests sent")
+    })
+    @GetMapping("/requests/sent")
+    public ResponseEntity<List<FriendRequestDTO>> getSentFriendRequests(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        User user = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        List<FriendRequest> requests = friendService.getSentPendingRequests(user);
+        List<FriendRequestDTO> requestDTOs = requests.stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+
+        return new ResponseEntity<>(requestDTOs, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Get all friends of the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of friends")
+    })
+    @GetMapping
+    public ResponseEntity<List<UserDTO>> getFriends(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        User user = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        List<User> friends = friendService.getFriends(user);
+        List<UserDTO> friendDTOs = friends.stream()
+                .map(this::convertToUserDTO)
+                .collect(Collectors.toList());
+
+        return new ResponseEntity<>(friendDTOs, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Remove a friend")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend removed successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request or friend not found"),
+            @ApiResponse(responseCode = "404", description = "Friend relationship does not exist")
+    })
+    @DeleteMapping("/{friendId}")
+    public ResponseEntity<Void> removeFriend(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long friendId) {
+
+        User user = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+
+        friendService.removeFriend(user, friendId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    /**
+     * Convert a FriendRequest entity to a DTO for API responses.
+     */
+    private FriendRequestDTO convertToDTO(FriendRequest request) {
+        return new FriendRequestDTO(
+                request.getId(),
+                convertToUserDTO(request.getSender()),
+                convertToUserDTO(request.getReceiver()),
+                request.getRequestTime(),
+                request.getResponseTime(),
+                request.getStatus().toString()
+        );
+    }
+
+    /**
+     * Convert a User entity to a simplified DTO for API responses.
+     */
+    private UserDTO convertToUserDTO(User user) {
+        return new UserDTO(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail()
+        );
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/controller/dto/FriendRequestDTO.java
+++ b/src/main/java/de/whs/wi/friends_and_places/controller/dto/FriendRequestDTO.java
@@ -1,0 +1,95 @@
+package de.whs.wi.friends_and_places.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * Data Transfer Object for friend requests.
+ * Used for sending friend request data in API responses.
+ */
+@Schema(description = "Friend request information")
+public class FriendRequestDTO {
+
+    @Schema(description = "Unique identifier of the request", example = "1")
+    private Long id;
+
+    @Schema(description = "User who sent the request")
+    private UserDTO sender;
+
+    @Schema(description = "User who received the request")
+    private UserDTO receiver;
+
+    @Schema(description = "When the request was sent", example = "2025-06-06T12:30:45")
+    private LocalDateTime requestTime;
+
+    @Schema(description = "When the request was responded to (accepted/declined)", example = "2025-06-06T14:15:22")
+    private LocalDateTime responseTime;
+
+    @Schema(description = "Current status of the request", example = "PENDING",
+            allowableValues = {"PENDING", "ACCEPTED", "DECLINED", "CANCELED"})
+    private String status;
+
+    // Constructors
+    public FriendRequestDTO() {
+    }
+
+    public FriendRequestDTO(Long id, UserDTO sender, UserDTO receiver,
+                            LocalDateTime requestTime, LocalDateTime responseTime, String status) {
+        this.id = id;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.requestTime = requestTime;
+        this.responseTime = responseTime;
+        this.status = status;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public UserDTO getSender() {
+        return sender;
+    }
+
+    public void setSender(UserDTO sender) {
+        this.sender = sender;
+    }
+
+    public UserDTO getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(UserDTO receiver) {
+        this.receiver = receiver;
+    }
+
+    public LocalDateTime getRequestTime() {
+        return requestTime;
+    }
+
+    public void setRequestTime(LocalDateTime requestTime) {
+        this.requestTime = requestTime;
+    }
+
+    public LocalDateTime getResponseTime() {
+        return responseTime;
+    }
+
+    public void setResponseTime(LocalDateTime responseTime) {
+        this.responseTime = responseTime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/controller/dto/UserDTO.java
+++ b/src/main/java/de/whs/wi/friends_and_places/controller/dto/UserDTO.java
@@ -1,0 +1,55 @@
+package de.whs.wi.friends_and_places.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Data Transfer Object for users.
+ * Used for sending simplified user data in API responses.
+ */
+@Schema(description = "User information")
+public class UserDTO {
+
+    @Schema(description = "Unique identifier of the user", example = "1")
+    private Long id;
+
+    @Schema(description = "Username of the user", example = "johndoe")
+    private String username;
+
+    @Schema(description = "Email address of the user", example = "john.doe@example.com")
+    private String email;
+
+    // Constructors
+    public UserDTO() {
+    }
+
+    public UserDTO(Long id, String username, String email) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/model/FriendRequest.java
+++ b/src/main/java/de/whs/wi/friends_and_places/model/FriendRequest.java
@@ -1,0 +1,149 @@
+package de.whs.wi.friends_and_places.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Entity representing a friend request between users.
+ * This tracks who sent the request, who received it, when it was sent,
+ * when it was responded to, and the current status.
+ */
+@Entity
+@Table(name = "friend_requests")
+public class FriendRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Column(nullable = false)
+    private LocalDateTime requestTime;
+
+    @Column
+    private LocalDateTime responseTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FriendRequestStatus status;
+
+    /**
+     * Enum representing the possible statuses of a friend request.
+     */
+    public enum FriendRequestStatus {
+        PENDING,    // Request has been sent but not yet accepted or declined
+        ACCEPTED,   // Request has been accepted, users are now friends
+        DECLINED,   // Request has been declined
+        CANCELED    // Request was canceled by the sender
+    }
+
+    // Constructors
+    public FriendRequest() {
+    }
+
+    public FriendRequest(User sender, User receiver) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.requestTime = LocalDateTime.now();
+        this.status = FriendRequestStatus.PENDING;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getSender() {
+        return sender;
+    }
+
+    public void setSender(User sender) {
+        this.sender = sender;
+    }
+
+    public User getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(User receiver) {
+        this.receiver = receiver;
+    }
+
+    public LocalDateTime getRequestTime() {
+        return requestTime;
+    }
+
+    public void setRequestTime(LocalDateTime requestTime) {
+        this.requestTime = requestTime;
+    }
+
+    public LocalDateTime getResponseTime() {
+        return responseTime;
+    }
+
+    public void setResponseTime(LocalDateTime responseTime) {
+        this.responseTime = responseTime;
+    }
+
+    public FriendRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(FriendRequestStatus status) {
+        this.status = status;
+    }
+
+    /**
+     * Accept this friend request.
+     * Updates the status to ACCEPTED and sets the response time.
+     */
+    public void accept() {
+        this.status = FriendRequestStatus.ACCEPTED;
+        this.responseTime = LocalDateTime.now();
+    }
+
+    /**
+     * Decline this friend request.
+     * Updates the status to DECLINED and sets the response time.
+     */
+    public void decline() {
+        this.status = FriendRequestStatus.DECLINED;
+        this.responseTime = LocalDateTime.now();
+    }
+
+    /**
+     * Cancel this friend request.
+     * Updates the status to CANCELED and sets the response time.
+     */
+    public void cancel() {
+        this.status = FriendRequestStatus.CANCELED;
+        this.responseTime = LocalDateTime.now();
+    }
+
+    /**
+     * Check if the request is still pending.
+     * @return true if the request is pending, false otherwise
+     */
+    public boolean isPending() {
+        return this.status == FriendRequestStatus.PENDING;
+    }
+
+    /**
+     * Check if the request was accepted.
+     * @return true if the request was accepted, false otherwise
+     */
+    public boolean isAccepted() {
+        return this.status == FriendRequestStatus.ACCEPTED;
+    }
+}

--- a/src/main/java/de/whs/wi/friends_and_places/model/User.java
+++ b/src/main/java/de/whs/wi/friends_and_places/model/User.java
@@ -1,6 +1,8 @@
 package de.whs.wi.friends_and_places.model;
 
 import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -23,6 +25,23 @@ public class User {
     private String street;
     private String houseNumber;
     private String mobile;
+
+    // Friend relationships
+    @ManyToMany
+    @JoinTable(
+        name = "user_friends",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "friend_id")
+    )
+    private Set<User> friends = new HashSet<>();
+
+    // Friend requests sent by this user
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL)
+    private Set<FriendRequest> sentFriendRequests = new HashSet<>();
+
+    // Friend requests received by this user
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL)
+    private Set<FriendRequest> receivedFriendRequests = new HashSet<>();
 
     public User() {
     }
@@ -109,5 +128,63 @@ public class User {
 
     public void setMobile(String mobile) {
         this.mobile = mobile;
+    }
+
+    // Friend management methods
+
+    public Set<User> getFriends() {
+        return friends;
+    }
+
+    public void setFriends(Set<User> friends) {
+        this.friends = friends;
+    }
+
+    public Set<FriendRequest> getSentFriendRequests() {
+        return sentFriendRequests;
+    }
+
+    public void setSentFriendRequests(Set<FriendRequest> sentFriendRequests) {
+        this.sentFriendRequests = sentFriendRequests;
+    }
+
+    public Set<FriendRequest> getReceivedFriendRequests() {
+        return receivedFriendRequests;
+    }
+
+    public void setReceivedFriendRequests(Set<FriendRequest> receivedFriendRequests) {
+        this.receivedFriendRequests = receivedFriendRequests;
+    }
+
+    /**
+     * Add a user as a friend.
+     * This adds the friend to this user's friends list and also adds this user to the friend's friends list.
+     *
+     * @param friend the user to add as a friend
+     */
+    public void addFriend(User friend) {
+        this.friends.add(friend);
+        friend.getFriends().add(this);
+    }
+
+    /**
+     * Remove a user from the friends list.
+     * This removes the friend from this user's friends list and also removes this user from the friend's friends list.
+     *
+     * @param friend the user to remove from the friends list
+     */
+    public void removeFriend(User friend) {
+        this.friends.remove(friend);
+        friend.getFriends().remove(this);
+    }
+
+    /**
+     * Check if a user is a friend of this user.
+     *
+     * @param user the user to check
+     * @return true if the user is a friend, false otherwise
+     */
+    public boolean isFriend(User user) {
+        return this.friends.contains(user);
     }
 }

--- a/src/main/java/de/whs/wi/friends_and_places/repository/FriendRequestRepository.java
+++ b/src/main/java/de/whs/wi/friends_and_places/repository/FriendRequestRepository.java
@@ -1,0 +1,63 @@
+package de.whs.wi.friends_and_places.repository;
+
+import de.whs.wi.friends_and_places.model.FriendRequest;
+import de.whs.wi.friends_and_places.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+
+    /**
+     * Find all friend requests received by a user with a specific status.
+     *
+     * @param receiver the user who received the requests
+     * @param status the status of the requests
+     * @return a list of friend requests
+     */
+    List<FriendRequest> findByReceiverAndStatus(User receiver, FriendRequest.FriendRequestStatus status);
+
+    /**
+     * Find all friend requests sent by a user with a specific status.
+     *
+     * @param sender the user who sent the requests
+     * @param status the status of the requests
+     * @return a list of friend requests
+     */
+    List<FriendRequest> findBySenderAndStatus(User sender, FriendRequest.FriendRequestStatus status);
+
+    /**
+     * Find pending friend request between two users.
+     *
+     * @param sender the user who sent the request
+     * @param receiver the user who received the request
+     * @return the friend request if it exists
+     */
+    Optional<FriendRequest> findBySenderAndReceiverAndStatus(
+            User sender, User receiver, FriendRequest.FriendRequestStatus status);
+
+    /**
+     * Check if a pending friend request exists between two users.
+     *
+     * @param sender the user who sent the request
+     * @param receiver the user who received the request
+     * @return true if a pending request exists, false otherwise
+     */
+    boolean existsBySenderAndReceiverAndStatus(
+            User sender, User receiver, FriendRequest.FriendRequestStatus status);
+
+    /**
+     * Find all pending friend requests for a user (both sent and received).
+     *
+     * @param user the user
+     * @return a list of pending friend requests
+     */
+    @Query("SELECT fr FROM FriendRequest fr WHERE " +
+           "(fr.sender = :user OR fr.receiver = :user) AND fr.status = 'PENDING'")
+    List<FriendRequest> findAllPendingRequestsForUser(@Param("user") User user);
+}

--- a/src/main/java/de/whs/wi/friends_and_places/service/FriendService.java
+++ b/src/main/java/de/whs/wi/friends_and_places/service/FriendService.java
@@ -1,0 +1,90 @@
+package de.whs.wi.friends_and_places.service;
+
+import de.whs.wi.friends_and_places.model.FriendRequest;
+import de.whs.wi.friends_and_places.model.User;
+
+import java.util.List;
+
+/**
+ * Service interface for managing friend requests.
+ */
+public interface FriendService {
+
+    /**
+     * Send a friend request from one user to another.
+     *
+     * @param sender the user sending the request
+     * @param receiverId the ID of the user receiving the request
+     * @return the created friend request
+     * @throws IllegalArgumentException if the receiver doesn't exist or sender tries to friend themselves
+     * @throws IllegalStateException if a pending request already exists or users are already friends
+     */
+    FriendRequest sendFriendRequest(User sender, Long receiverId);
+
+    /**
+     * Accept a friend request.
+     *
+     * @param requestId the ID of the friend request
+     * @param user the user accepting the request (must be the receiver)
+     * @return the accepted friend request
+     * @throws IllegalArgumentException if the request doesn't exist
+     * @throws IllegalStateException if the user is not the receiver or the request is not pending
+     */
+    FriendRequest acceptFriendRequest(Long requestId, User user);
+
+    /**
+     * Decline a friend request.
+     *
+     * @param requestId the ID of the friend request
+     * @param user the user declining the request (must be the receiver)
+     * @return the declined friend request
+     * @throws IllegalArgumentException if the request doesn't exist
+     * @throws IllegalStateException if the user is not the receiver or the request is not pending
+     */
+    FriendRequest declineFriendRequest(Long requestId, User user);
+
+    /**
+     * Cancel a friend request.
+     *
+     * @param requestId the ID of the friend request
+     * @param user the user canceling the request (must be the sender)
+     * @return the canceled friend request
+     * @throws IllegalArgumentException if the request doesn't exist
+     * @throws IllegalStateException if the user is not the sender or the request is not pending
+     */
+    FriendRequest cancelFriendRequest(Long requestId, User user);
+
+    /**
+     * Get all pending friend requests sent by a user.
+     *
+     * @param user the user
+     * @return a list of pending friend requests sent by the user
+     */
+    List<FriendRequest> getSentPendingRequests(User user);
+
+    /**
+     * Get all pending friend requests received by a user.
+     *
+     * @param user the user
+     * @return a list of pending friend requests received by the user
+     */
+    List<FriendRequest> getReceivedPendingRequests(User user);
+
+    /**
+     * Get all friends of a user.
+     *
+     * @param user the user
+     * @return a list of the user's friends
+     */
+    List<User> getFriends(User user);
+
+    /**
+     * Remove a friend relationship.
+     *
+     * @param user the user removing a friend
+     * @param friendId the ID of the friend to remove
+     * @throws IllegalArgumentException if the friend doesn't exist
+     * @throws IllegalStateException if the users are not friends
+     */
+    void removeFriend(User user, Long friendId);
+}

--- a/src/main/java/de/whs/wi/friends_and_places/service/implementations/FriendServiceImpl.java
+++ b/src/main/java/de/whs/wi/friends_and_places/service/implementations/FriendServiceImpl.java
@@ -1,0 +1,172 @@
+package de.whs.wi.friends_and_places.service.implementations;
+
+import de.whs.wi.friends_and_places.error.ResourceNotFoundException;
+import de.whs.wi.friends_and_places.model.FriendRequest;
+import de.whs.wi.friends_and_places.model.FriendRequest.FriendRequestStatus;
+import de.whs.wi.friends_and_places.model.User;
+import de.whs.wi.friends_and_places.repository.FriendRequestRepository;
+import de.whs.wi.friends_and_places.repository.UserRepository;
+import de.whs.wi.friends_and_places.service.FriendService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class FriendServiceImpl implements FriendService {
+
+    private final FriendRequestRepository friendRequestRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public FriendServiceImpl(FriendRequestRepository friendRequestRepository, UserRepository userRepository) {
+        this.friendRequestRepository = friendRequestRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional
+    public FriendRequest sendFriendRequest(User sender, Long receiverId) {
+        // Find the receiver
+        User receiver = userRepository.findById(receiverId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", receiverId));
+
+        // Validate that sender is not trying to friend themselves
+        if (sender.getId().equals(receiverId)) {
+            throw new IllegalArgumentException("You cannot send a friend request to yourself");
+        }
+
+        // Check if users are already friends
+        if (sender.isFriend(receiver)) {
+            throw new IllegalStateException("You are already friends with this user");
+        }
+
+        // Check if a pending request already exists
+        if (friendRequestRepository.existsBySenderAndReceiverAndStatus(
+                sender, receiver, FriendRequestStatus.PENDING)) {
+            throw new IllegalStateException("A pending friend request already exists");
+        }
+
+        // Check if the receiver has already sent a request to the sender
+        if (friendRequestRepository.existsBySenderAndReceiverAndStatus(
+                receiver, sender, FriendRequestStatus.PENDING)) {
+            throw new IllegalStateException("This user has already sent you a friend request");
+        }
+
+        // Create and save the friend request
+        FriendRequest friendRequest = new FriendRequest(sender, receiver);
+        return friendRequestRepository.save(friendRequest);
+    }
+
+    @Override
+    @Transactional
+    public FriendRequest acceptFriendRequest(Long requestId, User user) {
+        FriendRequest request = getFriendRequestAndValidateReceiver(requestId, user);
+
+        // Update request status
+        request.accept();
+
+        // Add the friendship relationship
+        user.addFriend(request.getSender());
+
+        // Save the updated request and user relationships
+        userRepository.save(user);
+        userRepository.save(request.getSender());
+        return friendRequestRepository.save(request);
+    }
+
+    @Override
+    @Transactional
+    public FriendRequest declineFriendRequest(Long requestId, User user) {
+        FriendRequest request = getFriendRequestAndValidateReceiver(requestId, user);
+
+        // Update request status
+        request.decline();
+
+        // Save the updated request
+        return friendRequestRepository.save(request);
+    }
+
+    @Override
+    @Transactional
+    public FriendRequest cancelFriendRequest(Long requestId, User user) {
+        // Find the request
+        FriendRequest request = friendRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ResourceNotFoundException("FriendRequest", "id", requestId));
+
+        // Verify the user is the sender
+        if (!request.getSender().getId().equals(user.getId())) {
+            throw new IllegalStateException("Only the sender can cancel a friend request");
+        }
+
+        // Verify the request is still pending
+        if (!request.isPending()) {
+            throw new IllegalStateException("Only pending requests can be canceled");
+        }
+
+        // Update request status
+        request.cancel();
+
+        // Save the updated request
+        return friendRequestRepository.save(request);
+    }
+
+    @Override
+    public List<FriendRequest> getSentPendingRequests(User user) {
+        return friendRequestRepository.findBySenderAndStatus(user, FriendRequestStatus.PENDING);
+    }
+
+    @Override
+    public List<FriendRequest> getReceivedPendingRequests(User user) {
+        return friendRequestRepository.findByReceiverAndStatus(user, FriendRequestStatus.PENDING);
+    }
+
+    @Override
+    public List<User> getFriends(User user) {
+        return new ArrayList<>(user.getFriends());
+    }
+
+    @Override
+    @Transactional
+    public void removeFriend(User user, Long friendId) {
+        // Find the friend
+        User friend = userRepository.findById(friendId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", friendId));
+
+        // Verify they are friends
+        if (!user.isFriend(friend)) {
+            throw new IllegalStateException("You are not friends with this user");
+        }
+
+        // Remove the friendship relationship
+        user.removeFriend(friend);
+
+        // Save the updated user relationships
+        userRepository.save(user);
+        userRepository.save(friend);
+    }
+
+    /**
+     * Helper method to find a friend request and validate that the given user is the receiver.
+     */
+    private FriendRequest getFriendRequestAndValidateReceiver(Long requestId, User user) {
+        // Find the request
+        FriendRequest request = friendRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ResourceNotFoundException("FriendRequest", "id", requestId));
+
+        // Verify the user is the receiver
+        if (!request.getReceiver().getId().equals(user.getId())) {
+            throw new IllegalStateException("Only the receiver can accept or decline a friend request");
+        }
+
+        // Verify the request is still pending
+        if (!request.isPending()) {
+            throw new IllegalStateException("Only pending requests can be accepted or declined");
+        }
+
+        return request;
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive implementation of friend management functionality, including sending, accepting, declining, and canceling friend requests, as well as managing friend relationships. The changes span multiple files, adding new controllers, data transfer objects (DTOs), models, repositories, and methods to handle these operations. Below is a summary of the most important changes grouped by theme:

### Friend Management API

* Added `FriendController` to handle friend-related operations, including sending, accepting, declining, and canceling friend requests, retrieving friends, and managing friend relationships. It includes REST endpoints with Swagger annotations for documentation.

### Data Transfer Objects (DTOs)

* Introduced `FriendRequestDTO` to represent friend request data in API responses, including sender, receiver, request time, response time, and status.
* Added `UserDTO` to represent simplified user data, including ID, username, and email, for API responses.

### Friend Request Entity

* Created `FriendRequest` entity to represent friend requests, with fields for sender, receiver, request time, response time, and status. Added methods to accept, decline, and cancel requests.

### User Entity Enhancements

* Updated `User` entity to include relationships for friends, sent friend requests, and received friend requests. Added methods to manage friends (e.g., add, remove, check friendship). [[1]](diffhunk://#diff-2ffb5bd2ccf331002e2ca23d946ce3ea25235c46d5ea6bd7ca91cbda62ef79a3R29-R45) [[2]](diffhunk://#diff-2ffb5bd2ccf331002e2ca23d946ce3ea25235c46d5ea6bd7ca91cbda62ef79a3R132-R189)

### Friend Request Repository

* Implemented `FriendRequestRepository` to handle database operations for friend requests, including finding requests by status, checking for pending requests, and retrieving all pending requests for a user.